### PR TITLE
Made symbolic & numerical inputs inline by default

### DIFF
--- a/Snippets/input:checkbox.tmSnippet
+++ b/Snippets/input:checkbox.tmSnippet
@@ -4,8 +4,9 @@
 <dict>
 	<key>content</key>
 	<string>&lt;numericalresponse answer="${1|3.14|}"&gt;
+	&lt;p style="display:inline" &gt; \(x=\) &lt;/p&gt;
 	&lt;responseparam type="tolerance" default="2%" /&gt;
-	&lt;textline label="for accessibility" trailing_text="" /&gt;
+	&lt;textline label="for accessibility" trailing_text="" inline="1" /&gt;
 &lt;/numericalresponse&gt;</string>
 	<key>name</key>
 	<string>input:numerical</string>

--- a/Snippets/input:symbolic.tmSnippet
+++ b/Snippets/input:symbolic.tmSnippet
@@ -4,9 +4,9 @@
 <dict>
 	<key>content</key>
 	<string>&lt;formularesponse answer="m*c^2" samples="m,c @ 1,1:10,10 #3"&gt;
-    &lt;text&gt;\(x=\)&lt;/text&gt;
+    &lt;p style="display:inline" &gt;\(E=\) &lt;/p&gt;
     &lt;responseparam default="1%" type="tolerance"/&gt;
-    &lt;formulaequationinput/&gt;
+    &lt;formulaequationinput inline="1"/&gt;
 &lt;/formularesponse&gt;</string>
 	<key>name</key>
 	<string>input:symbolic</string>


### PR DESCRIPTION
The tab triggers for formula response and numerical response now
generate templates with inline input fields by default.
