### PR TITLE
Improved default sampling settings on symbolic problems

### DIFF
--- a/Snippets/input:symbolic.tmSnippet
+++ b/Snippets/input:symbolic.tmSnippet
@@ -3,9 +3,9 @@
 <plist version="1.0">
 <dict>
 	<key>content</key>
-	<string>&lt;formularesponse answer="m*c^2" samples="m,c@ 1,1:10,10 #3"&gt;
+	<string>&lt;formularesponse answer="m*c^2" samples="m,c@ 0,0:2,2 #3"&gt;
     &lt;p style="display:inline" &gt;\(E=\) &lt;/p&gt;
-    &lt;responseparam default="1%" type="tolerance"/&gt;
+    &lt;responseparam default="0.01%" type="tolerance"/&gt;
     &lt;formulaequationinput inline="1"/&gt;
 &lt;/formularesponse&gt;</string>
 	<key>name</key>


### PR DESCRIPTION
Originally the samples were set as 1:10 #3 (three samples between 1 and 10) with tolerance of 1%. That was far too low for some problems in 8.MechCx, e.g., for finding derivatives of x(t) = t^5, both v(t)=5*t^4 and v(t)=5*t^4+1 might be accepted.